### PR TITLE
Implement support for activating A2A extensions from the client

### DIFF
--- a/lib/src/client/src/a2a_client.dart
+++ b/lib/src/client/src/a2a_client.dart
@@ -150,6 +150,10 @@ class A2AClient {
     final headers = http.Headers()
       ..append('Accept', 'application/json')
       ..append('Content-Type', 'text/event-stream');
+    if (params.extensions.isNotEmpty) {
+      headers.append('X-A2A-Extensions', params.extensions.join(','));
+    }
+
     final response = await http.fetch(
       endpoint,
       method: 'POST',
@@ -504,6 +508,9 @@ class A2AClient {
     final headers = http.Headers()
       ..append('Accept', 'application/json')
       ..append('Content-Type', 'application/json');
+    if (params is A2AMessageSendParams && params.extensions.isNotEmpty) {
+      headers.append('X-A2A-Extensions', params.extensions.join(','));
+    }
     final httpResponse = await http.fetch(
       endpoint,
       method: 'POST',

--- a/lib/src/types/src/area/a2a_request.dart
+++ b/lib/src/types/src/area/a2a_request.dart
@@ -368,6 +368,12 @@ class A2AMessageSendParams {
   /// Optional metadata for extensions.
   A2ASV? metadata;
 
+  /// A list of extensions the client intends to activate.
+  /// These are sent in the X-A2A-Extensions HTTP header and not in the
+  /// message body, hence they are not part of the JSON serialization.
+  @JsonKey(includeToJson: false, includeFromJson: false)
+  List<String> extensions = [];
+
   A2AMessageSendParams();
 
   factory A2AMessageSendParams.fromJson(Map<String, dynamic> json) =>


### PR DESCRIPTION
This PR implements client-side support for A2A extensions, allowing clients to
  activate agent capabilities beyond the core A2A specification.

  Key Changes:

   * `A2AMessageSendParams` Update:
       * A new extensions parameter has been added to the A2AMessageSendParams
         class. This allows clients to specify a list of extension URIs they
         wish to activate for a given request.

   * HTTP Header Implementation:
       * The A2AClient has been updated to check for the presence of the
         extensions parameter in A2AMessageSendParams.
       * If the extensions list is not empty, the client now adds the
         X-A2A-Extensions HTTP header to outgoing requests, with a
         comma-separated list of the requested extension URIs. This applies to
         both standard (sendMessage) and streaming (sendMessageStream) requests.

  This implementation follows the A2A extension specification, which you can
  find here:
  https://a2a-protocol.org/latest/topics/extensions/#extension-specification
  (https://a2a-protocol.org/latest/topics/extensions/#extension-specification)