### PR TITLE
fix(types): Correct AgentCard.security type to match spec

### DIFF
--- a/lib/src/types/a2a_types.g.dart
+++ b/lib/src/types/a2a_types.g.dart
@@ -1289,10 +1289,16 @@ A2AAgentCard _$A2AAgentCardFromJson(Map<String, dynamic> json) => A2AAgentCard()
   ..agentProvider = json['agentProvider'] == null
       ? null
       : A2AAgentProvider.fromJson(json['agentProvider'] as Map<String, dynamic>)
-  ..security = (json['security'] as Map<String, dynamic>?)?.map(
-    (k, e) =>
-        MapEntry(k, (e as List<dynamic>).map((e) => e as String).toList()),
-  )
+  ..security = (json['security'] as List<dynamic>?)
+      ?.map(
+        (e) => (e as Map<String, dynamic>).map(
+          (k, e) => MapEntry(
+            k,
+            (e as List<dynamic>).map((e) => e as String).toList(),
+          ),
+        ),
+      )
+      .toList()
   ..securitySchemes = (json['securitySchemes'] as Map<String, dynamic>?)?.map(
     (k, e) =>
         MapEntry(k, A2ASecurityScheme.fromJson(e as Map<String, dynamic>)),

--- a/lib/src/types/src/area/a2a_agent.dart
+++ b/lib/src/types/src/area/a2a_agent.dart
@@ -151,7 +151,7 @@ final class A2AAgentCard extends A2AAgent {
   /// This list can be seen as an OR of ANDs. Each object in the list describes one possible
   /// set of security requirements that must be present on a request. This allows specifying,
   /// for example, "callers must either use OAuth OR an API Key AND mTLS."
-  Map<String, List<String>>? security;
+  List<Map<String, List<String>>>? security;
 
   /// A declaration of the security schemes available to authorize requests. The key is the
   /// scheme name. Follows the OpenAPI 3.0 Security Scheme Object.


### PR DESCRIPTION
The `security` property on the `A2AAgentCard` class was incorrectly typed as `Map<String, List<String>>?`.

According to the A2A specification, this property should be a list of security requirement objects, making the correct Dart type `List<Map<String, List<String>>>?`.

This change aligns the Dart type with the official specification, resolving a validation error with the A2A Inspector and allowing a spec-compliant empty list (`[]`) to be assigned for agents with no security requirements.

The associated generated file (`a2a_types.g.dart`) has been updated by running `dart run build_runner build`.

Fixes #43 