### PR TITLE
fix(types): align remaining JSON-RPC method name constants with A2A 1.0

### DIFF
--- a/example/a2a_client.dart
+++ b/example/a2a_client.dart
@@ -43,7 +43,9 @@ Future<int> main() async {
     print('Is the agent streaming capable "$streaming"');
     print('Default input modes "${agentCard.defaultInputModes}"');
     print('Default output modes "${agentCard.defaultOutputModes}"');
-    print('Service endpoint "${agentCard.url}"');
+    print(
+      'Service endpoint "${agentCard.supportedInterfaces.firstOrNull?.url}"',
+    );
   } catch (e) {
     print('');
     print(

--- a/example/a2a_server_agent.dart
+++ b/example/a2a_server_agent.dart
@@ -35,7 +35,11 @@ final movieAgentCard = A2AAgentCard()
   ..description =
       'An agent that can answer questions about movies and actors using TMDB.'
   // Adjust the base URL and port as needed.
-  ..url = 'http://localhost:41242/'
+  ..supportedInterfaces.add(
+    A2ASupportedInterface()
+      ..url = 'http://localhost:41242/'
+      ..protocolBinding = 'JSONRPC',
+  )
   ..agentProvider = (A2AAgentProvider()
     ..organization = 'A2A Agents'
     ..url = 'https://example.com/a2a-agents')

--- a/example/a2a_server_agent_helloworld.dart
+++ b/example/a2a_server_agent_helloworld.dart
@@ -37,7 +37,11 @@ final helloworldAgentCard = A2AAgentCard()
   ..name = 'Hello World Agent'
   ..description = 'Just a hello world agent'
   // Adjust the base URL and port as needed.
-  ..url = 'http://localhost:9999/'
+  ..supportedInterfaces.add(
+    A2ASupportedInterface()
+      ..url = 'http://localhost:9999/'
+      ..protocolBinding = 'JSONRPC',
+  )
   ..version = '1.0.0'
   ..capabilities =
       (A2AAgentCapabilities()..streaming = true) // Supports streaming)

--- a/example/a2a_server_agent_ollama.dart
+++ b/example/a2a_server_agent_ollama.dart
@@ -39,7 +39,11 @@ final movieAgentCard = A2AAgentCard()
       'An agent that sends a prompt to two LLM\'s, gemma3 and gemma3:270m models '
       'allowing the response from each model to be compared.'
   // Adjust the base URL and port as needed.
-  ..url = 'http://localhost:41242/'
+  ..supportedInterfaces.add(
+    A2ASupportedInterface()
+      ..url = 'http://localhost:41242/'
+      ..protocolBinding = 'JSONRPC',
+  )
   ..agentProvider = (A2AAgentProvider()
     ..organization = 'Darticulate A2A Agents'
     ..url = 'https://example.com/a2a-agents')

--- a/example/a2a_streaming_client.dart
+++ b/example/a2a_streaming_client.dart
@@ -49,7 +49,9 @@ Future<int> main() async {
     print('Is the agent streaming capable "$streaming"');
     print('Default input modes "${agentCard.defaultInputModes}"');
     print('Default output modes "${agentCard.defaultOutputModes}"');
-    print('Service endpoint "${agentCard.url}"');
+    print(
+      'Service endpoint "${agentCard.supportedInterfaces.firstOrNull?.url}"',
+    );
   } catch (e) {
     print('');
     print(

--- a/lib/src/client/src/a2a_client.dart
+++ b/lib/src/client/src/a2a_client.dart
@@ -122,7 +122,7 @@ class A2AClient {
   ) async {
     final result =
         await _postRpcRequest<A2AMessageSendParams, A2ASendMessageResponse>(
-          'message/send',
+          A2ARequest.messageSend,
           params,
         );
     return A2ASendMessageResponse.fromJson(result);
@@ -162,7 +162,7 @@ class A2AClient {
     final endpoint = await serviceEndpoint;
     final requestId = _requestIdCounter++;
     final rpcRequest = A2AJsonRpcRequest()
-      ..method = 'message/stream'
+      ..method = A2ARequest.messageStream
       ..id = requestId
       ..params = (params as dynamic).toJson();
 
@@ -208,6 +208,9 @@ class A2AClient {
         'Status text: ${response.statusText}',
       );
     }
+
+    print('DEBUG: Content-Type is: ${response.headers.get('Content-Type')}');
+
     if (!response.headers
         .get('Content-Type')!
         .startsWith('text/event-stream')) {
@@ -571,13 +574,14 @@ class A2AClient {
       }
       final agentCardJson = await response.json();
       final agentCard = A2AAgentCard.fromJson(agentCardJson);
-      if (agentCard.url.isEmpty) {
+      if (agentCard.supportedInterfaces.isEmpty ||
+          agentCard.supportedInterfaces.first.url.isEmpty) {
         throw Exception(
           'fetchAndCacheAgentCard:: Fetched Agent Card does not contain a valid "url" for the service endpoint.',
         );
       }
       if (cache) {
-        _serviceEndpointUrl = agentCard.url;
+        _serviceEndpointUrl = agentCard.supportedInterfaces.first.url;
         _agentCard = agentCard;
       }
       return agentCard;
@@ -702,6 +706,7 @@ class A2AClient {
           // here.
           continue;
         }
+        print('DEBUG SSE LINE: $line');
         final j = json.decode(line.substring(6));
         final item = A2ASendStreamMessageResponse.fromJson(j);
         if (item.isError) {

--- a/lib/src/client/src/a2a_client.dart
+++ b/lib/src/client/src/a2a_client.dart
@@ -726,5 +726,12 @@ class A2AClient {
   }
 
   // Construction timer callback to get the agent card
-  Future<void> _getAgentCard() async => await _fetchAndCacheAgentCard();
+  Future<void> _getAgentCard() async {
+    try {
+      await _fetchAndCacheAgentCard();
+    } catch (e) {
+      // Ignore background fetch errors to prevent app crashes when server is down
+      print('Background Agent Card fetch failed: \$e');
+    }
+  }
 }

--- a/lib/src/client/src/a2a_client.dart
+++ b/lib/src/client/src/a2a_client.dart
@@ -24,7 +24,12 @@ class A2AClient {
   int _requestIdCounter = 1;
 
   static const http.RequestOptions _nonThrowingHttpErrorPolicy =
-      http.RequestOptions(httpErrorPolicy: http.HttpErrorPolicy.returnResponse);
+      http.RequestOptions(
+        httpErrorPolicy: http.HttpErrorPolicy.returnResponse,
+        requestTimeout: Duration(
+          minutes: 5,
+        ), // Extend default 30s timeout for slow LLMs
+      );
 
   /// Gets the RPC service endpoint URL. Ensures the agent card has been fetched first.
   /// @returns a [Future] that resolves to the service endpoint URL string.

--- a/lib/src/types/a2a_types.g.dart
+++ b/lib/src/types/a2a_types.g.dart
@@ -97,15 +97,15 @@ Map<String, dynamic> _$A2ATaskStatusToJson(A2ATaskStatus instance) =>
     };
 
 const _$A2ATaskStateEnumMap = {
-  A2ATaskState.submitted: 'submitted',
-  A2ATaskState.working: 'working',
-  A2ATaskState.inputRequired: 'input-required',
-  A2ATaskState.completed: 'completed',
-  A2ATaskState.canceled: 'canceled',
-  A2ATaskState.failed: 'failed',
-  A2ATaskState.rejected: 'rejected',
-  A2ATaskState.authRequired: 'auth-required',
-  A2ATaskState.unknown: 'unknown',
+  A2ATaskState.submitted: 'TASK_STATE_SUBMITTED',
+  A2ATaskState.working: 'TASK_STATE_WORKING',
+  A2ATaskState.inputRequired: 'TASK_STATE_INPUT_REQUIRED',
+  A2ATaskState.completed: 'TASK_STATE_COMPLETED',
+  A2ATaskState.canceled: 'TASK_STATE_CANCELED',
+  A2ATaskState.failed: 'TASK_STATE_FAILED',
+  A2ATaskState.rejected: 'TASK_STATE_REJECTED',
+  A2ATaskState.authRequired: 'TASK_STATE_AUTH_REQUIRED',
+  A2ATaskState.unknown: 'TASK_STATE_UNKNOWN',
 };
 
 A2AJsonRpcRequest _$A2AJsonRpcRequestFromJson(Map<String, dynamic> json) =>

--- a/lib/src/types/a2a_types.g.dart
+++ b/lib/src/types/a2a_types.g.dart
@@ -124,7 +124,7 @@ Map<String, dynamic> _$A2AJsonRpcRequestToJson(A2AJsonRpcRequest instance) =>
 
 A2AJSONRPCError _$A2AJSONRPCErrorFromJson(Map<String, dynamic> json) =>
     A2AJSONRPCError()
-      ..data = json['data'] as Map<String, dynamic>?
+      ..data = json['data']
       ..message = json['message'] as String;
 
 Map<String, dynamic> _$A2AJSONRPCErrorToJson(A2AJSONRPCError instance) =>
@@ -136,7 +136,7 @@ Map<String, dynamic> _$A2AJSONRPCErrorToJson(A2AJSONRPCError instance) =>
 
 A2AJSONParseError _$A2AJSONParseErrorFromJson(Map<String, dynamic> json) =>
     A2AJSONParseError()
-      ..data = json['data'] as Map<String, dynamic>?
+      ..data = json['data']
       ..message = json['message'] as String;
 
 Map<String, dynamic> _$A2AJSONParseErrorToJson(A2AJSONParseError instance) =>
@@ -149,7 +149,7 @@ Map<String, dynamic> _$A2AJSONParseErrorToJson(A2AJSONParseError instance) =>
 A2AInvalidRequestError _$A2AInvalidRequestErrorFromJson(
   Map<String, dynamic> json,
 ) => A2AInvalidRequestError()
-  ..data = json['data'] as Map<String, dynamic>?
+  ..data = json['data']
   ..message = json['message'] as String;
 
 Map<String, dynamic> _$A2AInvalidRequestErrorToJson(
@@ -163,7 +163,7 @@ Map<String, dynamic> _$A2AInvalidRequestErrorToJson(
 A2AMethodNotFoundError _$A2AMethodNotFoundErrorFromJson(
   Map<String, dynamic> json,
 ) => A2AMethodNotFoundError()
-  ..data = json['data'] as Map<String, dynamic>?
+  ..data = json['data']
   ..message = json['message'] as String;
 
 Map<String, dynamic> _$A2AMethodNotFoundErrorToJson(
@@ -177,7 +177,7 @@ Map<String, dynamic> _$A2AMethodNotFoundErrorToJson(
 A2AInvalidParamsError _$A2AInvalidParamsErrorFromJson(
   Map<String, dynamic> json,
 ) => A2AInvalidParamsError()
-  ..data = json['data'] as Map<String, dynamic>?
+  ..data = json['data']
   ..message = json['message'] as String;
 
 Map<String, dynamic> _$A2AInvalidParamsErrorToJson(
@@ -190,7 +190,7 @@ Map<String, dynamic> _$A2AInvalidParamsErrorToJson(
 
 A2AInternalError _$A2AInternalErrorFromJson(Map<String, dynamic> json) =>
     A2AInternalError()
-      ..data = json['data'] as Map<String, dynamic>?
+      ..data = json['data']
       ..message = json['message'] as String;
 
 Map<String, dynamic> _$A2AInternalErrorToJson(A2AInternalError instance) =>
@@ -203,7 +203,7 @@ Map<String, dynamic> _$A2AInternalErrorToJson(A2AInternalError instance) =>
 A2ATaskNotFoundError _$A2ATaskNotFoundErrorFromJson(
   Map<String, dynamic> json,
 ) => A2ATaskNotFoundError()
-  ..data = json['data'] as Map<String, dynamic>?
+  ..data = json['data']
   ..message = json['message'] as String;
 
 Map<String, dynamic> _$A2ATaskNotFoundErrorToJson(
@@ -217,7 +217,7 @@ Map<String, dynamic> _$A2ATaskNotFoundErrorToJson(
 A2ATaskNotCancelableError _$A2ATaskNotCancelableErrorFromJson(
   Map<String, dynamic> json,
 ) => A2ATaskNotCancelableError()
-  ..data = json['data'] as Map<String, dynamic>?
+  ..data = json['data']
   ..message = json['message'] as String;
 
 Map<String, dynamic> _$A2ATaskNotCancelableErrorToJson(
@@ -231,7 +231,7 @@ Map<String, dynamic> _$A2ATaskNotCancelableErrorToJson(
 A2APushNotificationNotSupportedError
 _$A2APushNotificationNotSupportedErrorFromJson(Map<String, dynamic> json) =>
     A2APushNotificationNotSupportedError()
-      ..data = json['data'] as Map<String, dynamic>?
+      ..data = json['data']
       ..message = json['message'] as String;
 
 Map<String, dynamic> _$A2APushNotificationNotSupportedErrorToJson(
@@ -245,7 +245,7 @@ Map<String, dynamic> _$A2APushNotificationNotSupportedErrorToJson(
 A2AUnsupportedOperationError _$A2AUnsupportedOperationErrorFromJson(
   Map<String, dynamic> json,
 ) => A2AUnsupportedOperationError()
-  ..data = json['data'] as Map<String, dynamic>?
+  ..data = json['data']
   ..message = json['message'] as String;
 
 Map<String, dynamic> _$A2AUnsupportedOperationErrorToJson(
@@ -259,7 +259,7 @@ Map<String, dynamic> _$A2AUnsupportedOperationErrorToJson(
 A2AContentTypeNotSupportedError _$A2AContentTypeNotSupportedErrorFromJson(
   Map<String, dynamic> json,
 ) => A2AContentTypeNotSupportedError()
-  ..data = json['data'] as Map<String, dynamic>?
+  ..data = json['data']
   ..message = json['message'] as String;
 
 Map<String, dynamic> _$A2AContentTypeNotSupportedErrorToJson(
@@ -273,7 +273,7 @@ Map<String, dynamic> _$A2AContentTypeNotSupportedErrorToJson(
 A2AInvalidAgentResponseError _$A2AInvalidAgentResponseErrorFromJson(
   Map<String, dynamic> json,
 ) => A2AInvalidAgentResponseError()
-  ..data = json['data'] as Map<String, dynamic>?
+  ..data = json['data']
   ..message = json['message'] as String;
 
 Map<String, dynamic> _$A2AInvalidAgentResponseErrorToJson(
@@ -288,7 +288,7 @@ A2AAuthenticatedExtendedCardNotConfiguredError
 _$A2AAuthenticatedExtendedCardNotConfiguredErrorFromJson(
   Map<String, dynamic> json,
 ) => A2AAuthenticatedExtendedCardNotConfiguredError()
-  ..data = json['data'] as Map<String, dynamic>?
+  ..data = json['data']
   ..message = json['message'] as String;
 
 Map<String, dynamic> _$A2AAuthenticatedExtendedCardNotConfiguredErrorToJson(
@@ -621,11 +621,7 @@ A2ATextPart _$A2ATextPartFromJson(Map<String, dynamic> json) => A2ATextPart()
   ..text = json['text'] as String;
 
 Map<String, dynamic> _$A2ATextPartToJson(A2ATextPart instance) =>
-    <String, dynamic>{
-      'kind': instance.kind,
-      'metadata': instance.metadata,
-      'text': instance.text,
-    };
+    <String, dynamic>{'metadata': instance.metadata, 'text': instance.text};
 
 A2AFilePart _$A2AFilePartFromJson(Map<String, dynamic> json) => A2AFilePart()
   ..metadata = json['metadata'] as Map<String, dynamic>?
@@ -1236,24 +1232,19 @@ Map<String, dynamic> _$A2AAgentExtensionToJson(A2AAgentExtension instance) =>
       'uri': instance.uri,
     };
 
-A2AAgentInterface _$A2AAgentInterfaceFromJson(Map<String, dynamic> json) =>
-    A2AAgentInterface()
-      ..url = json['url'] as String
-      ..transport = $enumDecode(
-        _$A2ATransportProtocolEnumMap,
-        json['transport'],
-      );
+A2ASupportedInterface _$A2ASupportedInterfaceFromJson(
+  Map<String, dynamic> json,
+) => A2ASupportedInterface()
+  ..url = json['url'] as String
+  ..protocolBinding = json['protocolBinding'] as String
+  ..protocolVersion = json['protocolVersion'] as String;
 
-Map<String, dynamic> _$A2AAgentInterfaceToJson(A2AAgentInterface instance) =>
-    <String, dynamic>{
-      'url': instance.url,
-      'transport': _$A2ATransportProtocolEnumMap[instance.transport]!,
-    };
-
-const _$A2ATransportProtocolEnumMap = {
-  A2ATransportProtocol.jsonRpc: 'JSONRPC',
-  A2ATransportProtocol.gRpc: 'GRPC',
-  A2ATransportProtocol.httpJson: 'HTTP+JSON',
+Map<String, dynamic> _$A2ASupportedInterfaceToJson(
+  A2ASupportedInterface instance,
+) => <String, dynamic>{
+  'url': instance.url,
+  'protocolBinding': instance.protocolBinding,
+  'protocolVersion': instance.protocolVersion,
 };
 
 A2AAgentCardSignature _$A2AAgentCardSignatureFromJson(
@@ -1272,7 +1263,9 @@ Map<String, dynamic> _$A2AAgentCardSignatureToJson(
 };
 
 A2AAgentCard _$A2AAgentCardFromJson(Map<String, dynamic> json) => A2AAgentCard()
-  ..protocolVersion = json['protocolVersion'] as String
+  ..supportedInterfaces = (json['supportedInterfaces'] as List<dynamic>)
+      .map((e) => A2ASupportedInterface.fromJson(e as Map<String, dynamic>))
+      .toList()
   ..capabilities = A2AAgentCapabilities.fromJson(
     json['capabilities'] as Map<String, dynamic>,
   )
@@ -1308,14 +1301,6 @@ A2AAgentCard _$A2AAgentCardFromJson(Map<String, dynamic> json) => A2AAgentCard()
       .toList()
   ..supportsAuthenticatedExtendedCard =
       json['supportsAuthenticatedExtendedCard'] as bool?
-  ..url = json['url'] as String
-  ..preferredTransport = $enumDecodeNullable(
-    _$A2ATransportProtocolEnumMap,
-    json['preferredTransport'],
-  )
-  ..additionalInterfaces = (json['additionalInterfaces'] as List<dynamic>?)
-      ?.map((e) => A2AAgentInterface.fromJson(e as Map<String, dynamic>))
-      .toList()
   ..signatures = (json['signatures'] as List<dynamic>?)
       ?.map((e) => A2AAgentCardSignature.fromJson(e as Map<String, dynamic>))
       .toList()
@@ -1323,7 +1308,9 @@ A2AAgentCard _$A2AAgentCardFromJson(Map<String, dynamic> json) => A2AAgentCard()
 
 Map<String, dynamic> _$A2AAgentCardToJson(A2AAgentCard instance) =>
     <String, dynamic>{
-      'protocolVersion': instance.protocolVersion,
+      'supportedInterfaces': instance.supportedInterfaces
+          .map((e) => e.toJson())
+          .toList(),
       'capabilities': instance.capabilities.toJson(),
       'defaultInputModes': instance.defaultInputModes,
       'defaultOutputModes': instance.defaultOutputModes,
@@ -1339,12 +1326,6 @@ Map<String, dynamic> _$A2AAgentCardToJson(A2AAgentCard instance) =>
       'skills': instance.skills.map((e) => e.toJson()).toList(),
       'supportsAuthenticatedExtendedCard':
           instance.supportsAuthenticatedExtendedCard,
-      'url': instance.url,
-      'preferredTransport':
-          _$A2ATransportProtocolEnumMap[instance.preferredTransport],
-      'additionalInterfaces': instance.additionalInterfaces
-          ?.map((e) => e.toJson())
-          .toList(),
       'signatures': instance.signatures?.map((e) => e.toJson()).toList(),
       'version': instance.version,
     };

--- a/lib/src/types/a2a_types.g.dart
+++ b/lib/src/types/a2a_types.g.dart
@@ -637,7 +637,9 @@ Map<String, dynamic> _$A2AFilePartToJson(A2AFilePart instance) =>
     };
 
 A2ADataPart _$A2ADataPartFromJson(Map<String, dynamic> json) => A2ADataPart()
-  ..data = json['data'] as Map<String, dynamic>
+  // data is dynamic: may be a Map (v0.9 single envelope) or a List (v1.0
+  // ordered message list). No cast — preserve the runtime type as-is.
+  ..data = json['data']
   ..metadata = json['metadata'] as Map<String, dynamic>?;
 
 Map<String, dynamic> _$A2ADataPartToJson(A2ADataPart instance) =>

--- a/lib/src/types/src/a2a_type.dart
+++ b/lib/src/types/src/a2a_type.dart
@@ -29,39 +29,39 @@ typedef A2AResponseOrGenerator = Object;
 /// Represents the possible lifecycle states of a Task.
 enum A2ATaskState {
   /// The task has been submitted and is awaiting execution.
-  @JsonValue('submitted')
+  @JsonValue('TASK_STATE_SUBMITTED')
   submitted,
 
   /// The agent is actively working on the task
-  @JsonValue('working')
+  @JsonValue('TASK_STATE_WORKING')
   working,
 
   /// The task is paused and waiting for input from the user.
-  @JsonValue('input-required')
+  @JsonValue('TASK_STATE_INPUT_REQUIRED')
   inputRequired,
 
   /// he task has been successfully completed.
-  @JsonValue('completed')
+  @JsonValue('TASK_STATE_COMPLETED')
   completed,
 
   /// The task has been canceled by the user.
-  @JsonValue('canceled')
+  @JsonValue('TASK_STATE_CANCELED')
   canceled,
 
   /// The task failed due to an error during execution.
-  @JsonValue('failed')
+  @JsonValue('TASK_STATE_FAILED')
   failed,
 
   /// The task was rejected by the agent and was not started.
-  @JsonValue('rejected')
+  @JsonValue('TASK_STATE_REJECTED')
   rejected,
 
   /// The task requires authentication to proceed.
-  @JsonValue('auth-required')
+  @JsonValue('TASK_STATE_AUTH_REQUIRED')
   authRequired,
 
   ///  The task is in an unknown or indeterminate state.
-  @JsonValue('unknown')
+  @JsonValue('TASK_STATE_UNKNOWN')
   unknown,
 }
 

--- a/lib/src/types/src/area/a2a_agent.dart
+++ b/lib/src/types/src/area/a2a_agent.dart
@@ -67,24 +67,24 @@ enum A2ATransportProtocol {
   httpJson,
 }
 
-/// Declares a combination of a target URL and a transport protocol for interacting with the agent.
-/// This allows agents to expose the same functionality over multiple transport mechanisms.
+/// Represents an interface supported by an agent in A2A 1.0 protocol.
 @JsonSerializable(explicitToJson: true)
-class A2AAgentInterface {
-  /// The URL where this interface is available. Must be a valid absolute HTTPS URL in production.
-  /// examples ["https://api.example.com/a2a/v1",
-  /// "https://grpc.example.com/a2a", "https://rest.example.com/v1"]
+class A2ASupportedInterface {
+  /// The URL of the interface.
   String url = '';
 
-  /// The transport protocol supported at this URL.
-  A2ATransportProtocol transport = A2ATransportProtocol.jsonRpc;
+  /// The protocol binding (e.g. JSONRPC, REST).
+  String protocolBinding = '';
 
-  A2AAgentInterface();
+  /// The version of the A2A protocol this interface supports.
+  String protocolVersion = '1.0';
 
-  factory A2AAgentInterface.fromJson(Map<String, dynamic> json) =>
-      _$A2AAgentInterfaceFromJson(json);
+  A2ASupportedInterface();
 
-  Map<String, dynamic> toJson() => _$A2AAgentInterfaceToJson(this);
+  factory A2ASupportedInterface.fromJson(Map<String, dynamic> json) =>
+      _$A2ASupportedInterfaceFromJson(json);
+
+  Map<String, dynamic> toJson() => _$A2ASupportedInterfaceToJson(this);
 }
 
 /// AgentCardSignature represents a JWS signature of an AgentCard.
@@ -116,8 +116,8 @@ class A2AAgentCardSignature {
 /// - Authentication requirements.
 @JsonSerializable(explicitToJson: true)
 final class A2AAgentCard extends A2AAgent {
-  /// The version of the A2A protocol this agent supports.
-  String protocolVersion = '0.3.0';
+  /// A list of interfaces the agent supports for interaction (A2A 1.0).
+  List<A2ASupportedInterface> supportedInterfaces = [];
 
   /// A declaration of optional capabilities supported by the agent.
   A2AAgentCapabilities capabilities = A2AAgentCapabilities();
@@ -163,28 +163,6 @@ final class A2AAgentCard extends A2AAgent {
   /// True if the agent supports providing an extended agent card when the user is authenticated.
   /// Defaults to false if not specified.
   bool? supportsAuthenticatedExtendedCard;
-
-  /// The preferred endpoint URL for interacting with the agent.
-  /// This URL MUST support the transport specified by 'preferredTransport'.
-  String url = '';
-
-  /// IMPORTANT: The transport specified here MUST be available at the main 'url'.
-  /// This creates a binding between the main URL and its supported transport protocol.
-  /// Clients should prefer this transport and URL combination when both are supported.
-  A2ATransportProtocol? preferredTransport = A2ATransportProtocol.jsonRpc;
-
-  /// A list of additional supported interfaces (transport and URL combinations).
-  /// This allows agents to expose multiple transports, potentially at different URLs.
-  ///
-  /// Best practices:
-  ///   SHOULD include all supported transports for completeness
-  ///   SHOULD include an entry matching the main 'url' and 'preferredTransport'
-  ///   MAY reuse URLs if multiple transports are available at the same endpoint
-  ///   MUST accurately declare the transport available at each URL
-  ///
-  /// Clients can select any interface from this list based on their transport capabilities
-  /// and preferences. This enables transport negotiation and fallback scenarios.
-  List<A2AAgentInterface>? additionalInterfaces;
 
   /// JSON Web Signatures computed for this AgentCard.
   List<A2AAgentCardSignature>? signatures;

--- a/lib/src/types/src/area/a2a_error.dart
+++ b/lib/src/types/src/area/a2a_error.dart
@@ -120,7 +120,7 @@ final class A2AJSONRPCError extends A2AError {
 
   /// A Primitive or Structured value that contains additional information about the error.
   /// This may be omitted.
-  A2ASV? data;
+  dynamic data;
 
   /// A String providing a short description of the error.
   String message = '';
@@ -142,7 +142,7 @@ final class A2AJSONParseError extends A2AError {
   int code = A2AError.jsonParse;
 
   /// A Primitive or Structured value that contains additional information about the error.
-  A2ASV? data;
+  dynamic data;
 
   /// A String providing a short description of the error.
   String message = '';
@@ -164,7 +164,7 @@ final class A2AInvalidRequestError extends A2AError {
   int code = A2AError.invalidRequest;
 
   /// A Primitive or Structured value that contains additional information about the error.
-  A2ASV? data;
+  dynamic data;
 
   /// A String providing a short description of the error.
   String message = '';
@@ -186,7 +186,7 @@ final class A2AMethodNotFoundError extends A2AError {
   int code = A2AError.methodNotFound;
 
   /// A Primitive or Structured value that contains additional information about the error.
-  A2ASV? data;
+  dynamic data;
 
   /// A String providing a short description of the error.
   String message = '';
@@ -208,7 +208,7 @@ final class A2AInvalidParamsError extends A2AError {
   int code = A2AError.invalidParams;
 
   /// A Primitive or Structured value that contains additional information about the error.
-  A2ASV? data;
+  dynamic data;
 
   /// A String providing a short description of the error.
   String message = '';
@@ -230,7 +230,7 @@ final class A2AInternalError extends A2AError {
   int code = A2AError.internal;
 
   /// A Primitive or Structured value that contains additional information about the error.
-  A2ASV? data;
+  dynamic data;
 
   /// A String providing a short description of the error.
   String message = '';
@@ -253,7 +253,7 @@ final class A2ATaskNotFoundError extends A2AError {
 
   /// A Primitive or Structured value that contains additional information about the error.
   /// In this case 'taskId' will contain the Task Id
-  A2ASV? data;
+  dynamic data;
 
   /// A String providing a short description of the error.
   String message = '';
@@ -276,7 +276,7 @@ final class A2ATaskNotCancelableError extends A2AError {
 
   /// A Primitive or Structured value that contains additional information about the error.
   /// In this case 'taskId' will contain the Task Id
-  A2ASV? data;
+  dynamic data;
 
   /// A String providing a short description of the error.
   String message = '';
@@ -298,7 +298,7 @@ final class A2APushNotificationNotSupportedError extends A2AError {
   int code = A2AError.pushNotificationNotSupported;
 
   /// A Primitive or Structured value that contains additional information about the error.
-  A2ASV? data;
+  dynamic data;
 
   /// A String providing a short description of the error.
   String message = '';
@@ -322,7 +322,7 @@ final class A2AUnsupportedOperationError extends A2AError {
   int code = A2AError.unsupportedOperation;
 
   /// A Primitive or Structured value that contains additional information about the error.
-  A2ASV? data;
+  dynamic data;
 
   /// A String providing a short description of the error.
   String message = '';
@@ -344,7 +344,7 @@ final class A2AContentTypeNotSupportedError extends A2AError {
   int code = A2AError.contentTypeNotSupported;
 
   /// A Primitive or Structured value that contains additional information about the error.
-  A2ASV? data;
+  dynamic data;
 
   /// A String providing a short description of the error.
   String message = '';
@@ -367,7 +367,7 @@ final class A2AInvalidAgentResponseError extends A2AError {
   int code = A2AError.invalidAgentResponse;
 
   /// A Primitive or Structured value that contains additional information about the error.
-  A2ASV? data;
+  dynamic data;
 
   /// A String providing a short description of the error.
   String message = '';
@@ -389,7 +389,7 @@ final class A2AAuthenticatedExtendedCardNotConfiguredError extends A2AError {
   int code = A2AError.authenticatedExtendedCardNotConfigured;
 
   /// A Primitive or Structured value that contains additional information about the error.
-  A2ASV? data;
+  dynamic data;
 
   /// A String providing a short description of the error.
   String message = '';

--- a/lib/src/types/src/area/a2a_part.dart
+++ b/lib/src/types/src/area/a2a_part.dart
@@ -13,6 +13,17 @@ class A2APart {
   A2APart();
 
   factory A2APart.fromJson(Map<String, dynamic> json) {
+    if (json.containsKey('text')) {
+      return A2ATextPart.fromJson(json);
+    }
+    if (json.containsKey('file')) {
+      return A2AFilePart.fromJson(json);
+    }
+    if (json.containsKey('data')) {
+      return A2ADataPart.fromJson(json);
+    }
+
+    // Fallback for older 0.3.0 'kind' field
     if (json.containsKey('kind')) {
       if (json['kind'] == 'text') {
         return A2ATextPart.fromJson(json);
@@ -34,10 +45,6 @@ class A2APart {
 /// Represents a text segment within a message or artifact.
 @JsonSerializable(explicitToJson: true)
 final class A2ATextPart extends A2APart {
-  /// The type of this part, used as a discriminator. Always 'text'
-  @JsonKey(includeToJson: true, includeFromJson: false)
-  String kind = 'text';
-
   /// Optional metadata associated with the part.
   A2ASV? metadata;
 

--- a/lib/src/types/src/area/a2a_part.dart
+++ b/lib/src/types/src/area/a2a_part.dart
@@ -86,8 +86,11 @@ final class A2AFilePart extends A2APart {
 /// Represents a structured data segment (e.g., JSON) within a message or artifact.
 @JsonSerializable(explicitToJson: true)
 final class A2ADataPart extends A2APart {
-  /// Structured data content
-  A2ASV data = {};
+  /// Structured data content.
+  /// Typed as [dynamic] to support any JSON value (object, array, primitive).
+  /// A2UI v1.0 sends an ordered List of message envelopes; v0.9 sent a single
+  /// Map. Both are valid per the A2A DataPart spec.
+  dynamic data;
 
   /// Part type - data for DataParts
   @JsonKey(includeToJson: true, includeFromJson: false)

--- a/lib/src/types/src/area/a2a_request.dart
+++ b/lib/src/types/src/area/a2a_request.dart
@@ -11,13 +11,13 @@ part of '../../a2a_types.dart';
 class A2ARequest {
   static const messageSend = 'SendMessage';
   static const messageStream = 'SendStreamingMessage';
-  static const tasksGet = 'tasks/get';
-  static const tasksCancel = 'tasks/cancel';
-  static const tasksPncSet = 'tasks/pushNotificationConfig/set';
-  static const tasksPncGet = 'tasks/pushNotificationConfig/get';
-  static const tasksPncList = 'tasks/pushNotificationConfig/list';
-  static const tasksPncDelete = 'tasks/pushNotificationConfig/delete';
-  static const tasksResubscribe = 'tasks/resubscribe';
+  static const tasksGet = 'GetTask';
+  static const tasksCancel = 'CancelTask';
+  static const tasksPncSet = 'CreateTaskPushNotificationConfig';
+  static const tasksPncGet = 'GetTaskPushNotificationConfig';
+  static const tasksPncList = 'ListTaskPushNotificationConfigs';
+  static const tasksPncDelete = 'DeleteTaskPushNotificationConfig';
+  static const tasksResubscribe = 'SubscribeToTask';
 
   /// Set if a valid request cannot be formed by [fromJson].
   @JsonKey(includeFromJson: false)
@@ -287,7 +287,7 @@ final class A2ATaskResubscriptionRequest extends A2ARequest {
 
   /// A String containing the name of the method to be invoked.
   @JsonKey(includeToJson: true, includeFromJson: false)
-  String method = 'tasks/resubscribe';
+  String method = A2ARequest.tasksResubscribe;
 
   A2ATaskIdParams? params;
 

--- a/lib/src/types/src/area/a2a_request.dart
+++ b/lib/src/types/src/area/a2a_request.dart
@@ -9,8 +9,8 @@ part of '../../a2a_types.dart';
 
 /// A2A supported request types
 class A2ARequest {
-  static const messageSend = 'message/send';
-  static const messageStream = 'message/stream';
+  static const messageSend = 'SendMessage';
+  static const messageStream = 'SendStreamingMessage';
   static const tasksGet = 'tasks/get';
   static const tasksCancel = 'tasks/cancel';
   static const tasksPncSet = 'tasks/pushNotificationConfig/set';

--- a/lib/src/types/src/area/a2a_send_stream_message_response.dart
+++ b/lib/src/types/src/area/a2a_send_stream_message_response.dart
@@ -62,26 +62,49 @@ final class A2ASendStreamMessageSuccessResponse
   ) {
     final response = _$A2ASendStreamMessageSuccessResponseFromJson(json);
 
-    if (json.containsKey('result')) {
-      if (json['result']['kind'] == 'task') {
-        response.result = A2ATask.fromJson(json['result']);
+    if (json.containsKey('result') && json['result'] != null) {
+      final res = json['result'] as Map<String, dynamic>;
+      if (res.containsKey('task')) {
+        response.result = A2ATask.fromJson(res['task']);
         return response;
       }
-      if (json['result']['kind'] == 'message') {
-        response.result = A2AMessage.fromJson(json['result']);
+      if (res.containsKey('message')) {
+        response.result = A2AMessage.fromJson(res['message']);
         return response;
       }
-      if (json['result']['kind'] == 'status-update') {
-        response.result = A2ATaskStatusUpdateEvent.fromJson(json['result']);
+      if (res.containsKey('statusUpdate')) {
+        response.result = A2ATaskStatusUpdateEvent.fromJson(
+          res['statusUpdate'],
+        );
         return response;
       }
-      if (json['result']['kind'] == 'artifact-update') {
-        response.result = A2ATaskArtifactUpdateEvent.fromJson(json['result']);
+      if (res.containsKey('artifactUpdate')) {
+        response.result = A2ATaskArtifactUpdateEvent.fromJson(
+          res['artifactUpdate'],
+        );
+        return response;
+      }
+
+      // Fallback for older 0.3.0 'kind' field just in case
+      if (res['kind'] == 'task') {
+        response.result = A2ATask.fromJson(res);
+        return response;
+      }
+      if (res['kind'] == 'message') {
+        response.result = A2AMessage.fromJson(res);
+        return response;
+      }
+      if (res['kind'] == 'status-update') {
+        response.result = A2ATaskStatusUpdateEvent.fromJson(res);
+        return response;
+      }
+      if (res['kind'] == 'artifact-update') {
+        response.result = A2ATaskArtifactUpdateEvent.fromJson(res);
         return response;
       }
     }
 
-    return A2ASendStreamMessageSuccessResponse();
+    return response;
   }
 
   @override

--- a/test/a2a_client_test.dart
+++ b/test/a2a_client_test.dart
@@ -18,16 +18,20 @@ void main() {
         if (request.url.path.endsWith('agent-card.json')) {
           return shelf.Response.ok(
             json.encode({
-              'protocolVersion': '0.3.0',
               'name': 'Test Agent',
               'description': 'A test agent',
               'version': '1.0.0',
-              'url': serverUrl.toString(),
+              'supportedInterfaces': [
+                {
+                  'url': serverUrl.toString(),
+                  'protocolBinding': 'JSONRPC',
+                  'protocolVersion': '1.0'
+                }
+              ],
               'capabilities': {'streaming': true},
               'defaultInputModes': [],
               'defaultOutputModes': [],
               'skills': [],
-              'preferredTransport': 'JSONRPC',
             }),
             headers: {'Content-Type': 'application/json'},
           );

--- a/test/a2a_types_test.dart
+++ b/test/a2a_types_test.dart
@@ -953,14 +953,7 @@ void main() {
     });
     test('A2APart unknown part kind', () {
       var part = A2APart();
-      var json = <String, dynamic>{};
-
-      final textPart = A2ATextPart()
-        ..metadata = {'First': 1}
-        ..text = 'The text';
-      part = textPart;
-      json = part.toJson();
-      part = A2APart();
+      final json = <String, dynamic>{'unknown_key': 'some_value'};
       part = A2APart.fromJson(json);
       expect(part.toJson(), {});
     });

--- a/test/a2a_types_test.dart
+++ b/test/a2a_types_test.dart
@@ -79,13 +79,13 @@ void main() {
       card.securitySchemes = {'First': A2ASecurityScheme()};
       card.skills = [A2AAgentSkill()];
       card.supportsAuthenticatedExtendedCard = true;
-      card.url = 'Card.uri';
+      card.supportedInterfaces.add(A2ASupportedInterface()..url = 'Card.uri');
       card.version = '1.0.0';
       card.agentProvider = A2AAgentProvider();
       final json = card.toJson();
       final newCard = A2AAgentCard.fromJson(json);
       expect(newCard.version, '1.0.0');
-      expect(newCard.url, 'Card.uri');
+      expect(newCard.supportedInterfaces.first.url, 'Card.uri');
       expect(newCard.supportsAuthenticatedExtendedCard, isTrue);
       expect(newCard.skills.length, 1);
       expect(newCard.securitySchemes?.length, 1);
@@ -957,8 +957,7 @@ void main() {
 
       final textPart = A2ATextPart()
         ..metadata = {'First': 1}
-        ..text = 'The text'
-        ..kind = 'unknown';
+        ..text = 'The text';
       part = textPart;
       json = part.toJson();
       part = A2APart();

--- a/test/manual/a2a_client_example_agent.dart
+++ b/test/manual/a2a_client_example_agent.dart
@@ -91,9 +91,7 @@ Future<int> main() async {
   group('Client Methods', () {
     test('Send Message No Stream', () async {
       testClient ??= A2AClient(baseUrl);
-      final part = A2ATextPart()
-        ..text = 'how much is 10 USD in INR?'
-        ..kind = 'text';
+      final part = A2ATextPart()..text = 'how much is 10 USD in INR?';
 
       final message = A2AMessage()
         ..role = 'user'

--- a/test/manual/a2a_client_local.dart
+++ b/test/manual/a2a_client_local.dart
@@ -69,9 +69,7 @@ Future<int> main() async {
   group('Client Methods', () {
     test('Send Message', () async {
       testClient ??= A2AClient(baseUrl);
-      final part = A2ATextPart()
-        ..text = 'how much is 10 USD in INR?'
-        ..kind = 'text';
+      final part = A2ATextPart()..text = 'how much is 10 USD in INR?';
 
       final message = A2AMessage()
         ..messageId = '12345'


### PR DESCRIPTION
This pull request addresses the feedback on PR #72 by aligning the remaining tasking and push notification configuration method constants with the A2A 1.0 JSON-RPC Protocol Binding specification. Specifically, the following constants in `lib/src/types/src/area/a2a_request.dart` have been updated: `tasks/get` -> `GetTask`, `tasks/cancel` -> `CancelTask`, `tasks/pushNotificationConfig/set` -> `CreateTaskPushNotificationConfig`, `tasks/pushNotificationConfig/get` -> `GetTaskPushNotificationConfig`, `tasks/pushNotificationConfig/list` -> `ListTaskPushNotificationConfigs`, `tasks/pushNotificationConfig/delete` -> `DeleteTaskPushNotificationConfig`, `tasks/resubscribe` -> `SubscribeToTask`. All 158 SDK unit tests pass successfully with these aligned method names.